### PR TITLE
Conditionally set WP_ENVIRONMENT_TYPE

### DIFF
--- a/inc/set-env-vars.php
+++ b/inc/set-env-vars.php
@@ -9,7 +9,9 @@ $server_vars = isset( $_SERVER ) ? $_SERVER : false;
 
 // Set proper env var for env type.
 if ( getenv( 'LANDO' ) ) {
-	define( 'WP_ENVIRONMENT_TYPE', 'local' );
+	if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+		define( 'WP_ENVIRONMENT_TYPE', 'local' );
+	}
 
 	if ( ! defined( 'WP_DEVELOPMENT_MODE' ) ) {
 		define( 'WP_DEVELOPMENT_MODE', 'all' );


### PR DESCRIPTION
Setting here without checking if it's defined first causes a conflict with Bedrock. roots/bedrock defines this in `config/application.php` as this is called before the plugin.

[Link to predefined constant in Bedrock.](https://github.com/roots/bedrock/blob/2736c8681d83f0de8b720e7a6c478b23da81cc00/config/application.php#L56)

```
/**
 * Set up our global environment constant and load its config first
 * Default: production
 */
define('WP_ENV', env('WP_ENV') ?: 'production');

/**
 * Infer WP_ENVIRONMENT_TYPE based on WP_ENV
 */
if (!env('WP_ENVIRONMENT_TYPE') && in_array(WP_ENV, ['production', 'staging', 'development', 'local'])) {
    Config::define('WP_ENVIRONMENT_TYPE', WP_ENV);
}
```